### PR TITLE
Server reworkings, `ChangePage`-packet and code cleanup

### DIFF
--- a/MakefileNSO
+++ b/MakefileNSO
@@ -35,7 +35,7 @@ TARGET		?=	$(notdir $(CURDIR))$(S2VER)
 BUILD		?=	build$(S2VER)
 SOURCES		:=	source source/fl
 DATA		:=	data
-INCLUDES	:=	include
+INCLUDES	:=	include include/sead
 
 #---------------------------------------------------------------------------------
 # options for code generation
@@ -45,9 +45,9 @@ ARCH	:=	-march=armv8-a -mtune=cortex-a57 -mtp=soft -fPIC -ftls-model=local-exec
 CFLAGS	:=	-g -Wall -ffunction-sections \
 			$(ARCH) $(DEFINES)
 
-CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -DSMOVER=$(S2VER) -DSMOVERSTR=$(S2VERSTR) -D_NEW
+CFLAGS	+=	$(INCLUDE) -D__SWITCH__ -DSMOVER=$(S2VER) -DSMOVERSTR=$(S2VERSTR)
 
-CXXFLAGS	:= $(CFLAGS) -fno-rtti -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables -D_NEW
+CXXFLAGS	:= $(CFLAGS) -fno-rtti -fomit-frame-pointer -fno-exceptions -fno-asynchronous-unwind-tables -fno-unwind-tables
 
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS  =  -specs=../switch.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map) -Wl,--version-script=$(TOPDIR)/exported.txt -Wl,-init=__custom_init -Wl,-fini=__custom_fini -nostdlib

--- a/include/fl/game.h
+++ b/include/fl/game.h
@@ -1,0 +1,26 @@
+#pragma once
+
+class StageScene;
+class PlayerActorHakoniwa;
+
+namespace fl {
+
+class Game {
+public:
+    static inline Game& instance() {static Game ui; return ui;}
+    void setStageScene(StageScene* stage_scene);
+    PlayerActorHakoniwa* getPlayer() const;
+
+    void killMario();
+    void damageMario(int amount);
+    void lifeUpHeart();
+    void healMario();
+    void removeCappy();
+    void invincibilityStar();
+
+private:
+    StageScene* mStageScene;
+
+};
+
+}

--- a/include/fl/packet.h
+++ b/include/fl/packet.h
@@ -25,7 +25,7 @@ namespace smo
 
     enum InPacketType : u8
     {
-        PlayerScriptInfo = 1, PlayerScriptData = 2, PlayerTeleport = 3, PlayerGo = 4
+        PlayerScriptInfo = 1, PlayerScriptData = 2, PlayerTeleport = 3, PlayerGo = 4, ChangePage = 5
     };
 
     class InPacket
@@ -77,6 +77,14 @@ namespace smo
 
     class InPacketPlayerScriptData : public InPacket
     {
+    public:
+        void parse(const u8* data, u32 len);
+        void on(Server& server);
+    };
+
+    class InPacketChangePage : public InPacket
+    {
+        u8 page;
     public:
         void parse(const u8* data, u32 len);
         void on(Server& server);

--- a/include/fl/server.h
+++ b/include/fl/server.h
@@ -5,6 +5,9 @@
 #include <nn/socket.h>
 #include <types.h>
 
+#define SERVER_PORT 7902
+#define CLIENT_PORT 7901
+
 namespace smo
 {
     class OutPacket;
@@ -13,12 +16,14 @@ namespace smo
     {
     private:
         bool connected = false;
+        bool started = false;
 
         void* threadStack = nullptr;
         nn::os::ThreadType* thread = nullptr;
     public:
-        void sendInit();
-        u8 connect(const char* ip, u16 port);
+        void sendInit(const char* ip);
+        void start();
+        void connect(const char* ip);
         void disconnect();
         void sendPacket(OutPacket& packet, OutPacketType type);
         bool isConnected();

--- a/include/fl/ui.h
+++ b/include/fl/ui.h
@@ -57,6 +57,14 @@ public:
     bool isModeE3MovieRom = false;
     bool isModeEpdMovieRom = false;
     bool isModeJungleGymRom = false;
+    
+    enum Page : u8
+    {
+        About, Options, Stage, Misc, Info, Tas, MoonInfo, Modes, Debug
+    };
+
+    Page curPage = About;
+    u8 curLine = 0;
 };
 
 }

--- a/source/debugMenu.cpp
+++ b/source/debugMenu.cpp
@@ -1,5 +1,6 @@
 #include "debugMenu.hpp"
 #include "fl/ui.h"
+#include "fl/server.h"
 #include <al/util.hpp>
 
 // These files must exist in your romfs! they are not there by default, and must be added in order for the debug font to work correctly.
@@ -55,6 +56,8 @@ void setupDebugMenu(GameSystem *gSys) {
     }else {
         //gLogger->LOG("Failed to get Heap!\n");
     }
+
+    smo::Server::instance().start();
 
     __asm("MOV W23, #0x3F800000");
     __asm("MOV W8, #0xFFFFFFFF");

--- a/source/fl/game.cpp
+++ b/source/fl/game.cpp
@@ -1,0 +1,52 @@
+#include "fl/game.h"
+
+#include <game/GameData/GameDataFunction.h>
+#include <game/Player/PlayerActorHakoniwa.h>
+#include <game/StageScene/StageScene.h>
+#include "rs/util.hpp"
+
+namespace fl {
+
+void Game::setStageScene(StageScene* stage_scene) {
+    mStageScene = stage_scene;
+}
+
+PlayerActorHakoniwa* Game::getPlayer() const {
+    return rs::getPlayerActor(mStageScene);
+}
+
+void Game::killMario() {
+    getPlayer()->mDamageKeeper->dead();
+}
+
+void Game::damageMario(int amount) {
+    getPlayer()->mDamageKeeper->damage(amount);
+}
+
+void Game::lifeUpHeart() {
+    #if SMOVER==100
+    mStageScene->mHolder->mGameDataFile->getPlayerHitPointData()->getMaxUpItem();
+    #endif
+    #if SMOVER==130
+    GameDataFunction::getLifeMaxUpItem(getPlayer());
+    #endif
+}
+
+void Game::healMario() {
+    #if SMOVER==100
+    mStageScene->mHolder->mGameDataFile->getPlayerHitPointData()->recover();
+    #endif
+    #if SMOVER==130
+    GameDataFunction::recoveryPlayer(getPlayer());
+    #endif
+}
+
+void Game::removeCappy() {
+    GameDataFunction::disableCapByPlacement(getPlayer()->mHackCap);
+}
+
+void Game::invincibilityStar() {
+    getPlayer()->mDamageKeeper->activatePreventDamage();
+}
+
+}

--- a/source/fl/packet.cpp
+++ b/source/fl/packet.cpp
@@ -121,4 +121,14 @@ namespace smo
     }
 
     void InPacketPlayerScriptData::on(Server& server) {}
+
+    void InPacketChangePage::parse(const u8* data, u32 len)
+    {
+        page = data[0];
+    }
+
+    void InPacketChangePage::on(Server &server)
+    {
+        fl::PracticeUI::instance().curPage = (fl::PracticeUI::Page) page;
+    }
 }

--- a/source/fl/server.cpp
+++ b/source/fl/server.cpp
@@ -127,6 +127,7 @@ namespace smo
             IN_PACKET(PlayerTeleport);
             IN_PACKET(PlayerGo);
             IN_PACKET(PlayerScriptData);
+            IN_PACKET(ChangePage);
             default: break;
         }
     }

--- a/source/fl/ui.cpp
+++ b/source/fl/ui.cpp
@@ -4,6 +4,7 @@
 #include "rs/util.hpp"
 
 #include <fl/common.h>
+#include <fl/game.h>
 #include <fl/server.h>
 #include <fl/input.h>
 #include <fl/tas.h>
@@ -76,6 +77,7 @@ void fl::PracticeUI::loadPosition(PlayerActorHakoniwa& player)
 
 void fl::PracticeUI::update(StageScene& stageScene)
 {
+    Game::instance().setStageScene(&stageScene);
     this->stageScene = &stageScene;
     isInGame = true;
 
@@ -279,28 +281,14 @@ void fl::PracticeUI::menu()
                 CHANGE_PAGE();
 
                 TRIGGER("Kill Mario\n", 1, {
-                    player->mDamageKeeper->dead();
+                    Game::instance().killMario();
                     curLine = 0;
                 });
-                TRIGGER("Damage Mario\n", 2, player->mDamageKeeper->damage(1));
-                TRIGGER("Life Up Heart\n", 3, {
-                    #if SMOVER==100
-                    stageScene->mHolder->mGameDataFile->getPlayerHitPointData()->getMaxUpItem();
-                    #endif
-                    #if SMOVER==130
-                    GameDataFunction::getLifeMaxUpItem(player);
-                    #endif
-                });
-                TRIGGER("Heal Mario\n", 4, {
-                    #if SMOVER==100
-                    stageScene->mHolder->mGameDataFile->getPlayerHitPointData()->recover();
-                    #endif
-                    #if SMOVER==130
-                    GameDataFunction::recoveryPlayer(player);
-                    #endif
-                });
-                TRIGGER("Remove Cappy\n", 5, GameDataFunction::disableCapByPlacement(cappy));
-                TRIGGER("Invincibility Star\n", 6, player->mDamageKeeper->activatePreventDamage());
+                TRIGGER("Damage Mario\n", 2, Game::instance().damageMario(1));
+                TRIGGER("Life Up Heart\n", 3, Game::instance().lifeUpHeart());
+                TRIGGER("Heal Mario\n", 4, Game::instance().healMario());
+                TRIGGER("Remove Cappy\n", 5, Game::instance().removeCappy());
+                TRIGGER("Invincibility Star\n", 6, Game::instance().invincibilityStar());
                 
                 static u8 gravity = 0;
 

--- a/source/fl/ui.cpp
+++ b/source/fl/ui.cpp
@@ -144,12 +144,6 @@ void fl::PracticeUI::menu()
     if (!stageScene) return;
     if (showMenu)
     {
-        enum Page : u8
-        {
-            About, Options, Stage, Misc, Info, Tas, MoonInfo, Modes, Debug
-        };
-        static Page curPage = About;
-        static s8 curLine = 0;
         const char* charCursor = " ";
 
         PlayerActorHakoniwa* player = rs::getPlayerActor(stageScene);

--- a/source/fl/ui.cpp
+++ b/source/fl/ui.cpp
@@ -419,7 +419,7 @@ void fl::PracticeUI::menu()
 
                 #if SMOVER==100
                 TRIGGER("Connect to server\n", 1, {
-                    //smo::Server::instance().connect("someip", 7902);
+                    //smo::Server::instance().connect("someip");
                 });
                 TOGGLE("Old Motion Mod: %s\n", fl::TasHolder::instance().oldMotion, 2);
 


### PR DESCRIPTION
First off, a bit of work has been done on the server, which results in being able to set up the UDP server on boot instead of on trying to connect to the server. Later, this can be further extended into being able to initialize a connection from the PC instead of the switch.

About that change, I'm not sure if more `#if SMOVER==...` are required. Could you have a look at it, and tell me any places where it is missing? Maybe in [debugMenu.cpp](https://github.com/MonsterDruide1/smo-practice/blob/ea0742dc448a4af0b0f76111dc5acb8040a252c9/source/debugMenu.cpp#L60), but I'm honestly unsure about the call structure of it, and whether it is only called in 1.0 or can also be called in other versions?

Next up, moving the `enum Page` and `curPage`/`curLine` stuff into the header instead of static inline in the function results in cleaner code and being able to modify the code from outside, as with the next commit:

The newly added `ChangePage`-command (`5`) can flip through the pages remotely, for example when automatically running a discord bot for streaming scripts.

For a bit of code cleanup, a few things from the `Misc` menu have been moved into a separate file. This is kind-of a proof-of-concept of the structure right now, as I'm unsure whether this is the best solution... but moving away most of the functional code from the UI definitely is not a bad idea.

And finally, I found those changes in my `MakefileNSO`. During testing for `Game.h`, I played around with the `seadDisposer.h` header, which includes a bunch of other headers, which do not comply the Starlight-project setup. Using these changes, compiling will work again, and they don't seem to have any impact on the output in all other cases... so why not keep them, if we decide to include `sead` classes at a different point later?