### PR TITLE
Refresh left input for version 1.3.0

### DIFF
--- a/source/fl/ui/ui.cpp
+++ b/source/fl/ui/ui.cpp
@@ -138,6 +138,8 @@ void fl::ui::PracticeUI::menu(sead::TextWriter& p)
 #if SMOVER == 130
     al::showPane(getStageScene()->stageSceneLayout->coinCounter, "TxtDebug");
     al::setPaneStringFormat(getStageScene()->stageSceneLayout->coinCounter, "TxtDebug", textBuffer);
+
+    nextFrameNoLeftInput = false;
 #elif SMOVER == 100
     p.printf(textBuffer);
 #endif


### PR DESCRIPTION
When hiding and then unhiding the UI in version 1.3.0, `nextFrameNoLeftInput` is set to `true` and is then never set to `false`, causing the UI to be unresponsive. This commit should fix that.