### PR TITLE
Fix v1.3.0 debug page

### DIFF
--- a/include/game/GameData/GameDataFunction.h
+++ b/include/game/GameData/GameDataFunction.h
@@ -20,13 +20,11 @@ public:
     // Gets the required number of moons required to leave a kingdom
     #if(SMOVER==100)
     static s32 findUnlockShineNumByWorldId(bool*, GameDataHolderAccessor, int); // 0x004d53c0
-    static s32 getCurrentWorldId(GameDataHolderAccessor); // 0x004d2de0
     static s32 getCurrentShineNum(GameDataHolderAccessor); // 0x004d3C60
     static s32 getTotalShineNum(GameDataHolderAccessor, int); // 0x004d4490
     #endif
     #if(SMOVER==130)
     static WEFUN(0x004D53C0, s32, findUnlockShineNumByWorldId, EFUN_ARGS(bool* something, GameDataHolderAccessor accessor, int something2), EFUN_ARGS(something, accessor, something2));
-    static WEFUN(0x004D2DE0, s32, getCurrentWorldId, EFUN_ARGS(GameDataHolderAccessor accessor), EFUN_ARGS(accessor));
     static WEFUN(0x004D3C60, s32, getCurrentShineNum, EFUN_ARGS(GameDataHolderAccessor accessor), EFUN_ARGS(accessor));
     static WEFUN(0x004D4490, s32, getTotalShineNum, EFUN_ARGS(GameDataHolderAccessor accessor, int something), EFUN_ARGS(accessor, something));
     #endif
@@ -40,11 +38,19 @@ public:
     static s32 calcNextScenarioNo(GameDataHolderAccessor);
     // gets total moons collected on a specified save file (-1 for current save)
     // gets the total amount of moons available in a kingdom
-    static s32 getWorldTotalShineNum(GameDataHolderAccessor, int); 
+    static s32 getWorldTotalShineNum(GameDataHolderAccessor, int);
+
+    #if(SMOVER==100)
     // gets the current scenario No of the specified kingdom
     static s32 getWorldScenarioNo(GameDataHolderAccessor, int);
-
+    static s32 getCurrentWorldId(GameDataHolderAccessor); // 0x004d2de0
     static char* getCurrentStageName(GameDataHolderAccessor);
+    #endif
+    #if(SMOVER==130)
+    static WEFUN(0x004D5890, s32, getWorldScenarioNo, EFUN_ARGS(GameDataHolderAccessor* accessor, int worldId), EFUN_ARGS(accessor, worldId));
+    static WEFUN(0x004D2DE0, s32, getCurrentWorldId, EFUN_ARGS(GameDataHolderAccessor *accessor), EFUN_ARGS(accessor));
+    static WEFUN(0x004DB1C0, char*, getCurrentStageName, EFUN_ARGS(GameDataHolderAccessor *accessor), EFUN_ARGS(accessor));
+    #endif
 
     static char* getMainStageName(GameDataHolderAccessor, int);
 

--- a/include/game/GameData/GameDataHolder.h
+++ b/include/game/GameData/GameDataHolder.h
@@ -45,7 +45,6 @@ public:
     void invalidateSaveForMoonGet();
     void validateSaveForMoonGet();
     void setLanguage(char const *);
-    char* getLanguage() const;
 
     void resetLocationName();
     void changeNextStageWithDemoWorldWarp(char const *);
@@ -64,9 +63,11 @@ public:
     
     #if(SMOVER==100)
     char* getCurrentStageName() const;
+    char* getLanguage() const;
     #endif
     #if(SMOVER==130)
     CVEFUN(GameDataHolder, 0x004DB1C0, char*, getCurrentStageName);
+    CVEFUN(GameDataHolder, 0x004DB030, char*, getLanguage);
     #endif
     char* tryGetCurrentStageName() const;
     char* getCurrentStageName(s32 idx) const;

--- a/include/game/StageScene/StageScene.h
+++ b/include/game/StageScene/StageScene.h
@@ -31,12 +31,12 @@ class StageScene : public al::Scene
         spad(gap1, 0x20);
         StageSceneLayout* stageSceneLayout; // 0x2F8
         spad(gap2, 0x1B8);
-        HelpAmiiboDirector* mHelpAmiiboDirector;
+        HelpAmiiboDirector* mHelpAmiiboDirector; // 0x4B8
         #endif
         #if(SMOVER==130)
-        spad(inherit, 0x2E8 - sizeof(al::Scene));
-        GameDataHolderAccessor* mHolder; // 0x2E8
-        spad(gap1, 0x18);
+        spad(inherit, 0x2E0 - sizeof(al::Scene));
+        GameDataHolderAccessor* mHolder; // 0x2E0
+        spad(gap1, 0x20);
         StageSceneLayout* stageSceneLayout; // 0x308
         #endif
 };

--- a/patches/100.slpatch
+++ b/patches/100.slpatch
@@ -44,7 +44,7 @@ StageScene::control+18:
 002a1a98:
     bl isGotShineVar
 
-// toogle warps
+// toggle warps
 001f6b0c:
     b isEnableCheckpointWarpVar
 001f35c0:

--- a/source/fl/ui/p_debug.cpp
+++ b/source/fl/ui/p_debug.cpp
@@ -4,13 +4,19 @@
 
 void fl::ui::debug::update(PracticeUI& ui)
 {
-    StageScene* stageScene = ui.getStageScene();
+	StageScene* stageScene = ui.getStageScene();
 #if (SMOVER == 100)
-    ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(*stageScene->mHolder, GameDataFunction::getCurrentWorldId(*stageScene->mHolder)));
-    ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(*stageScene->mHolder));
-    ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(*stageScene->mHolder));
-    ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
+	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(*stageScene->mHolder, GameDataFunction::getCurrentWorldId(*stageScene->mHolder)));
+	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(*stageScene->mHolder));
+	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(*stageScene->mHolder));
+	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 #endif
-    ui.printf("\n");
-    ui.printf(" Practice Mod Version: %s\n", PRACTICE_VERSTR);
+#if (SMOVER == 130)
+	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(stageScene->mHolder, GameDataFunction::getCurrentWorldId(stageScene->mHolder)));
+	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(stageScene->mHolder));
+	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(stageScene->mHolder));
+	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
+#endif
+	ui.printf("\n");
+	ui.printf(" Practice Mod Version: %s\n", PRACTICE_VERSTR);
 }


### PR DESCRIPTION
The GameDataHolderAccessor pointer ``mHolder`` in StageScene was incorrectly placed in the memory, so the gap was changed accordingly.

Then after updating the memory locations for the functions in the debug page, passing mHolder as a pointer (without dereferencing) worked.