### PR TITLE
Update sendPatch.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,10 @@ S2VER ?= 100
 S2VERSTR ?= 1.0.0
 S2ROMTYPE ?= US
 
+# Edit this line to enable FTP connection with "make send".
+# If the FTP connection is password protected, the username and password need to be set in sendPatch.py.
+#IP ?= 192.168.0.0
+
 all: starlight
 
 starlight:

--- a/patches/100.slpatch
+++ b/patches/100.slpatch
@@ -44,7 +44,7 @@ StageScene::control+18:
 002a1a98:
     bl isGotShineVar
 
-// toogle warps
+// toggle warps
 001f6b0c:
     b isEnableCheckpointWarpVar
 001f35c0:

--- a/scripts/sendPatch.py
+++ b/scripts/sendPatch.py
@@ -85,12 +85,12 @@ for patchDir in patchDirectories:
             print(f'Sending {sdPath}')
             ftp.storbinary(f'STOR {sdPath}', open(fullPath, 'rb'))
 
-ensuredirectory(ftp, '/atmosphere', 'titles')
-ensuredirectory(ftp, '/atmosphere/titles', titleIdLookup[romType])
-ensuredirectory(ftp, f'/atmosphere/titles/{titleIdLookup[romType]}', 'exefs')
+ensuredirectory(ftp, '/atmosphere', 'contents')
+ensuredirectory(ftp, '/atmosphere/contents', titleIdLookup[romType])
+ensuredirectory(ftp, f'/atmosphere/contents/{titleIdLookup[romType]}', 'exefs')
 
 binaryPath = f'{os.path.basename(os.getcwd())}{version}.nso'
 if os.path.isfile(binaryPath):
-    sdPath = f'/atmosphere/titles/{titleIdLookup[romType]}/exefs/subsdk0'
+    sdPath = f'/atmosphere/contents/{titleIdLookup[romType]}/exefs/subsdk1'
     print(f'Sending {sdPath}')
     ftp.storbinary(f'STOR {sdPath}', open(binaryPath, 'rb'))

--- a/scripts/sendPatch.py
+++ b/scripts/sendPatch.py
@@ -61,6 +61,7 @@ curDir = os.curdir
 ftp = FTP()
 print(f'Connecting to {consoleIP}... ', end='')
 ftp.connect(consoleIP, consolePort)
+#ftp.login(user="admin", passwd="admin")
 print('Connected!')
 
 patchDirectories = []

--- a/scripts/sendPatch.py
+++ b/scripts/sendPatch.py
@@ -3,14 +3,16 @@ import os
 import sys
 
 titleIdLookup = {
-    "JP": '01003C700009C000',
-    "US": '01003BC0000A0000',
-    "EU": '0100F8F0000A2000',
-    'EveJP': '0100D070040F8000',
-    'EveUS': '01003870040FA000',
-    'EveEU': '010086F0040FC000',
-    'TrialUS': '01006BB00D45A000',
-    'ShowDL': '010000A00218E000'
+    "US": '0100000000010000'
+
+#    Splatoon 2 IDs used in the original Starlight.
+#    "JP": '01003C700009C000',
+#    "EU": '0100F8F0000A2000',
+#    'EveJP': '0100D070040F8000',
+#    'EveUS': '01003870040FA000',
+#    'EveEU': '010086F0040FC000',
+#    'TrialUS': '01006BB00D45A000',
+#    'ShowDL': '010000A00218E000'
 }
 
 


### PR DESCRIPTION
It seems sendPatch was outdated and not adjusted to work for Odyssey (the title IDs were still Splatoon 2's title IDs).