### PR TITLE
Fix v1.3.0 stage selection

### DIFF
--- a/include/game/StageScene/ChangeStageInfo.h
+++ b/include/game/StageScene/ChangeStageInfo.h
@@ -51,8 +51,9 @@ private:
     s32 mUnkInt;
     spad(unk, 0x4);
     #endif
+    #if(SMOVER==130)
+    spad(padding, 0x278);
+    #endif
 };
 
-#if(SMOVER==100)
 static_assert(sizeof(ChangeStageInfo) == 0x278);
-#endif

--- a/include/game/StageScene/ChangeStageInfo.h
+++ b/include/game/StageScene/ChangeStageInfo.h
@@ -18,11 +18,6 @@ public:
     ChangeStageInfo(const GameDataHolder*, const al::PlacementInfo&);
     ChangeStageInfo(const GameDataHolder*, const al::PlacementInfo&, const char* entranceName, const char* stageName, bool, int scenario, ChangeStageInfo::SubScenarioType);
     ChangeStageInfo(const GameDataHolder*, const char* entranceName, const char* stageName, bool, int scenario, ChangeStageInfo::SubScenarioType);
-    #endif
-    #if(SMOVER==130)
-    VCEFUN_CTOR(ChangeStageInfo, 0x0021C040, EFUN_ARGS(const GameDataHolder* holder, const char* entranceName, const char* stageName, bool something, int scenario, ChangeStageInfo::SubScenarioType subScenarioType), EFUN_ARGS(holder, entranceName, stageName, something, scenario, subScenarioType));
-    #endif
-
     void copy(const ChangeStageInfo&);
     s32 findScenarioNoByList(const GameDataHolder*); // return type(?)
     void init();
@@ -30,6 +25,19 @@ public:
     bool isSubScenarioTypeLifeRecover() const;
     bool isSubScenarioTypeResetMiniGame() const;
     void setWipeType(const char* type);
+    #endif
+    #if(SMOVER==130)
+    VCEFUN_CTOR(ChangeStageInfo, 0x0021BA10, EFUN_ARGS(const GameDataHolder* holder, const al::PlacementInfo& placementInfo), EFUN_ARGS(holder, placementInfo));
+    VCEFUN_CTOR(ChangeStageInfo, 0x0021BDD0, EFUN_ARGS(const GameDataHolder* holder, const al::PlacementInfo& placementInfo, const char* entranceName, const char* stageName, bool something, int scenario, ChangeStageInfo::SubScenarioType subScenarioType), EFUN_ARGS(holder, placementInfo, entranceName, stageName, something, scenario, subScenarioType));
+    VCEFUN_CTOR(ChangeStageInfo, 0x0021C040, EFUN_ARGS(const GameDataHolder* holder, const char* entranceName, const char* stageName, bool something, int scenario, ChangeStageInfo::SubScenarioType subScenarioType), EFUN_ARGS(holder, entranceName, stageName, something, scenario, subScenarioType));
+    VCEFUN(ChangeStageInfo, 0x0021C240, copy, EFUN_ARGS(const ChangeStageInfo &info), EFUN_ARGS(info));
+    s32 findScenarioNoByList(const GameDataHolder*); // return type(?)
+    VVCEFUN(ChangeStageInfo, 0x0021C1D0, init);
+    VCEFUN(ChangeStageInfo, 0x0021BB20, init, EFUN_ARGS(const al::PlacementInfo& placementInfo, const GameDataHolder* holder), EFUN_ARGS(placementInfo, holder));
+    CVEFUN(ChangeStageInfo, 0x0021C580, bool, isSubScenarioTypeLifeRecover);
+    CVEFUN(ChangeStageInfo, 0x0021C5A0, bool, isSubScenarioTypeResetMiniGame);
+    VCEFUN(ChangeStageInfo, 0x0021C5C0, setWipeType, EFUN_ARGS(const char* type), EFUN_ARGS(type));
+    #endif
 private:
     #if(SMOVER==100)
     sead::FixedSafeString<128> mStageEntranceName;

--- a/include/game/StageScene/ChangeStageInfo.h
+++ b/include/game/StageScene/ChangeStageInfo.h
@@ -31,7 +31,7 @@ public:
     VCEFUN_CTOR(ChangeStageInfo, 0x0021BDD0, EFUN_ARGS(const GameDataHolder* holder, const al::PlacementInfo& placementInfo, const char* entranceName, const char* stageName, bool something, int scenario, ChangeStageInfo::SubScenarioType subScenarioType), EFUN_ARGS(holder, placementInfo, entranceName, stageName, something, scenario, subScenarioType));
     VCEFUN_CTOR(ChangeStageInfo, 0x0021C040, EFUN_ARGS(const GameDataHolder* holder, const char* entranceName, const char* stageName, bool something, int scenario, ChangeStageInfo::SubScenarioType subScenarioType), EFUN_ARGS(holder, entranceName, stageName, something, scenario, subScenarioType));
     VCEFUN(ChangeStageInfo, 0x0021C240, copy, EFUN_ARGS(const ChangeStageInfo &info), EFUN_ARGS(info));
-    s32 findScenarioNoByList(const GameDataHolder*); // return type(?)
+    s32 findScenarioNoByList(const GameDataHolder*); // Haven't been able to find the address of the v1.3.0 equivalent.
     VVCEFUN(ChangeStageInfo, 0x0021C1D0, init);
     VCEFUN(ChangeStageInfo, 0x0021BB20, init, EFUN_ARGS(const al::PlacementInfo& placementInfo, const GameDataHolder* holder), EFUN_ARGS(placementInfo, holder));
     CVEFUN(ChangeStageInfo, 0x0021C580, bool, isSubScenarioTypeLifeRecover);

--- a/source/fl/ui/p_debug.cpp
+++ b/source/fl/ui/p_debug.cpp
@@ -9,14 +9,13 @@ void fl::ui::debug::update(PracticeUI& ui)
 	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(*stageScene->mHolder, GameDataFunction::getCurrentWorldId(*stageScene->mHolder)));
 	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(*stageScene->mHolder));
 	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(*stageScene->mHolder));
-	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 #endif
 #if (SMOVER == 130)
 	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(stageScene->mHolder, GameDataFunction::getCurrentWorldId(stageScene->mHolder)));
 	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(stageScene->mHolder));
 	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(stageScene->mHolder));
-	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 #endif
+	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 	ui.printf("\n");
 	ui.printf(" Practice Mod Version: %s\n", PRACTICE_VERSTR);
 }

--- a/source/fl/ui/p_stages.cpp
+++ b/source/fl/ui/p_stages.cpp
@@ -11,10 +11,6 @@ void fl::ui::stages::update(PracticeUI& ui)
     static int currentStage = 0;
     static int currentScenario = 1;
 
-#if SMOVER == 130
-    ui.printf(MSG_NO130);
-    return;
-#endif
     ui.cursor(1);
     if (ui.inputEnabled && ui.curLine == 1) {
         if (al::isPadTriggerRight(CONTROLLER_AUTO) && !ui.nextFrameNoRightInput)


### PR DESCRIPTION
When debugging with GDB, it seems the construction of the FixedSafeString objects inside ChangeStageInfo crashes the game. Removing the class members and padding for the entire class size seems to solve this problem.

It's not possible to load stages when your save game is not "ready" for it, e.g. loading post-game scenarios before achieving world peace. I haven't tried the mod on v1.0.0, so I can't tell how these caveats compare to the v1.0.0 usage.