### PR TITLE
Fix v1.3.0 scenario number

### DIFF
--- a/include/game/GameData/GameDataFile.h
+++ b/include/game/GameData/GameDataFile.h
@@ -24,6 +24,7 @@ class GameDataFile
         void setGotShine(const ShineInfo*);
         #endif
         #if(SMOVER==130)
+        CEFUN(GameDataFile, 0x004C65F0, s32, getScenarioNo, EFUN_ARGS(int worldId), EFUN_ARGS(worldId));
         CVEFUN(GameDataFile, 0x004C8530, PlayerHitPointData*, getPlayerHitPointData);
         CEFUN(GameDataFile, 0x004C9880, bool, isGotShine, EFUN_ARGS(const ShineInfo* shineInfo), EFUN_ARGS(shineInfo));
         VCEFUN(GameDataFile, 0x004C9880, setGotShine, EFUN_ARGS(const ShineInfo* info), EFUN_ARGS(info));

--- a/include/game/GameData/GameDataFunction.h
+++ b/include/game/GameData/GameDataFunction.h
@@ -47,7 +47,6 @@ public:
     static char* getCurrentStageName(GameDataHolderAccessor);
     #endif
     #if(SMOVER==130)
-    static WEFUN(0x004D5890, s32, getWorldScenarioNo, EFUN_ARGS(GameDataHolderAccessor* accessor, int worldId), EFUN_ARGS(accessor, worldId));
     static WEFUN(0x004D2DE0, s32, getCurrentWorldId, EFUN_ARGS(GameDataHolderAccessor *accessor), EFUN_ARGS(accessor));
     static WEFUN(0x004DB1C0, char*, getCurrentStageName, EFUN_ARGS(GameDataHolderAccessor *accessor), EFUN_ARGS(accessor));
     #endif

--- a/source/fl/ui/p_debug.cpp
+++ b/source/fl/ui/p_debug.cpp
@@ -11,7 +11,7 @@ void fl::ui::debug::update(PracticeUI& ui)
 	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(*stageScene->mHolder));
 #endif
 #if (SMOVER == 130)
-	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(stageScene->mHolder, GameDataFunction::getCurrentWorldId(stageScene->mHolder)));
+	ui.printf(" Current Scenario: %d\n", stageScene->mHolder->mGameDataFile->getScenarioNo(GameDataFunction::getCurrentWorldId(stageScene->mHolder)));
 	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(stageScene->mHolder));
 	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(stageScene->mHolder));
 #endif

--- a/source/fl/ui/p_debug.cpp
+++ b/source/fl/ui/p_debug.cpp
@@ -9,14 +9,13 @@ void fl::ui::debug::update(PracticeUI& ui)
 	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(*stageScene->mHolder, GameDataFunction::getCurrentWorldId(*stageScene->mHolder)));
 	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(*stageScene->mHolder));
 	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(*stageScene->mHolder));
-	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 #endif
 #if (SMOVER == 130)
 	ui.printf(" Current Scenario: %d\n", GameDataFunction::getWorldScenarioNo(stageScene->mHolder, GameDataFunction::getCurrentWorldId(stageScene->mHolder)));
 	ui.printf(" Current World ID: %d\n", GameDataFunction::getCurrentWorldId(stageScene->mHolder));
 	ui.printf(" Current Stage Name: %s\n", GameDataFunction::getCurrentStageName(stageScene->mHolder));
-	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 #endif
+	ui.printf(" Language: %s\n", stageScene->mHolder->getLanguage());
 	ui.printf("\n");
 	ui.printf(" Practice Mod Version: %s\n", PRACTICE_VERSTR);
 }


### PR DESCRIPTION
Version 1.0.0 has GameDataFunction::getWorldScenarioNum and GameDataFunction::getWorldScenarioNo. For version 1.3.0, I used the address of the former, but needed the address of the latter.

However, v1.3.0 doesn't seem to have a GameDataFunction::getWorldScenarioNo. Instead, it has GameDataFile::getScenarioNo. So I updated GameDataFunction.h, GameDataFile.h and p_debug.cpp accordingly.

The debug page now displays the scenario numbers correctly.