### PR TITLE
Fix v1.3.0 bowser skip

### DIFF
--- a/patches/130.slpatch
+++ b/patches/130.slpatch
@@ -46,5 +46,5 @@ StageScene::control+18:
     bl isEnableSaveVar
 
 // toggle bowser skip
-00473080:
+004B581C:
     bl isDefeatKoopaLv1Var

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -53,7 +53,29 @@ bool isEnableSaveVar(StageScene* stageScene)
 
 bool isDefeatKoopaLv1Var(StageScene* stageScene)
 {
+#if SMOVER == 100
     return fl::ui::PracticeUI::instance().skipBowser ? true : stageScene->isDefeatKoopaLv1();
+#endif
+#if SMOVER == 130
+    static int functionCalls = 0;
+    if (!fl::ui::PracticeUI::instance().skipBowser) {
+        functionCalls = 0;
+        return stageScene->isDefeatKoopaLv1();
+    }
+
+    // When debugging, returning true right away will skip Lost and go straight to (Day!) Metro with a broken Odyssey back in Wooded.
+    // Since isDefeatKoopaLv1 is called multiple times, we can return false the first time, then return true the second time, which
+    // seems to correctly skip the Bowser fight. This is a very hacky way of skipping the Bowser fight, so if there is some way to
+    // deduce from other game variables which function call we're in, that would be ideal. It would eliminate the need to introduce
+    // our own variable to keep track of the number of isDefeatKoopaLv1 calls.
+    functionCalls++;
+    if (functionCalls == 2) {
+        functionCalls = 0;
+        return true;
+    }
+
+    return false;
+#endif
 }
 
 bool isTriggerSnapShotModeVar(const al::IUseSceneObjHolder* objHolder)


### PR DESCRIPTION
Currently, the Bowser skip crashes the game due to a faulty memory address in the Starlight patch. After correcting, the Bowser skip skips both Cloud, Lost and Night Metro for v1.3.0. Whether the game goes to Bowser (Cloud) is controlled by isDefeatKoopaLv1. If you set that to true, it will skip Cloud, Lost and Night Metro. isDefeatKoopaLv1 is called multiple times. If you keep it false the 1st time, but make it true the 2nd time, you will go to Lost as intended and the skip seems to work correctly.

To emulate this behavior, I just added a counter (initialize at 0) in the mod:
1st isDefeatKoopaLv1 call: counter++. return counter == 2 (now false).
2nd isDefeatKoopaLv1 call: counter++. return counter == 2 (now true, so we'll put the counter back at 0, too).

It's not elegant, but it seems to work.