### PR TITLE
Correct the v1.3.0 isGotShine memory address

### DIFF
--- a/include/game/GameData/GameDataFile.h
+++ b/include/game/GameData/GameDataFile.h
@@ -26,7 +26,7 @@ class GameDataFile
         #if(SMOVER==130)
         CEFUN(GameDataFile, 0x004C65F0, s32, getScenarioNo, EFUN_ARGS(int worldId), EFUN_ARGS(worldId));
         CVEFUN(GameDataFile, 0x004C8530, PlayerHitPointData*, getPlayerHitPointData);
-        CEFUN(GameDataFile, 0x004C9880, bool, isGotShine, EFUN_ARGS(const ShineInfo* shineInfo), EFUN_ARGS(shineInfo));
+        CEFUN(GameDataFile, 0x004C9700, bool, isGotShine, EFUN_ARGS(const ShineInfo* shineInfo), EFUN_ARGS(shineInfo));
         VCEFUN(GameDataFile, 0x004C9880, setGotShine, EFUN_ARGS(const ShineInfo* info), EFUN_ARGS(info));
         #endif
 


### PR DESCRIPTION
Up until now, the address for isGotShine was actually the address for setGotShine. This resulted in the player obtaining all available moons upon entering any area.

This has now been corrected. I think v1.3.0 can now be played normally again.